### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+# The Fares Tech team will be the default owners for everything in
+# the phil repo.
+*       @mbta/fares-technology


### PR DESCRIPTION
No ticket, allows a fares tech team member to be requested for review by default. 